### PR TITLE
Upgrade to Zig 0.14.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-zig-cache
+.zig-cache

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .zig-cache
+*.local.md

--- a/LICENSE
+++ b/LICENSE
@@ -2,6 +2,8 @@ Copyright (c) 2017, 2021 Pieter Wuille
 Copyright (c) 2017 Takatoshi Nakagawa
 Copyright (c) 2019 Google LLC
 Copyright (c) 2021 Stephen Gregoratto
+Copyright (c) 2023 Chris Heyes
+Copyright (c) 2025 Eli Grubb
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,0 +1,60 @@
+# Zig Bech32
+
+A Zig implementation of Bech32 and Bech32m encoding/decoding as specified in [BIP-173](https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki) and [BIP-350](https://github.com/bitcoin/bips/blob/master/bip-0350.mediawiki).
+
+## Features
+
+- Complete Bech32 and Bech32m support
+- Generic encoder/decoder implementation
+- Comprehensive error handling
+- Single-file library with no external dependencies
+- Extensive test coverage with official BIP test vectors
+
+## Installation
+
+Requires Zig 0.14.0+.
+
+```bash
+zig fetch --save git+https://github.com/eligrubb/zig-bech32.git
+```
+
+## Usage
+
+```zig
+const bech32 = @import("bech32");
+
+// Encoding
+const hrp = "ziglang";
+const data = [_]u8{ 0xde, 0xad, 0xbe, 0xef };
+const enc = bech32.Encoding.bech32m;
+var buf: [bech32.max_string_size]u8 = undefined;
+const str = bech32.standard.Encoder.encode(&buf, hrp, data, enc);
+
+// Decoding
+var data_buf: [bech32.max_data_size]u8 = undefined;
+const res = try bech32.standard.Decoder.decode(&data_buf, str);
+```
+
+## Testing
+
+```bash
+zig build test
+```
+
+## Format
+
+A Bech32 string consists of:
+1. **Human readable part (HRP)**: 1-83 characters
+2. **Separator**: "1"
+3. **Data**: 5-bit values encoded using Bech32 charset
+4. **Checksum**: 30-bit value expanded to six 5-bit values
+
+Maximum string length is 90 characters.
+
+## Notes
+
+- This implementation is not constant-time
+- Outputs lowercase strings by default
+- Uppercase transformation available via compile-time flag
+- Fork of [zig-bech32](https://github.com/The-King-of-Toasters/zig-bech32) with Zig 0.14.1+ compatibility
+- Known issue with [bech32m encoding](https://github.com/The-King-of-Toasters/zig-bech32/issues/2)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,28 @@
+# Release Notes - v0.1.0
+
+## Version 0.1.0 - Zig 0.14.1 Compatibility Update
+
+This is the first release of our fork of [zig-bech32](https://github.com/The-King-of-Toasters/zig-bech32/).
+
+### Main Features
+
+- **Zig 0.14.1 Support**: Updated the library to be compatible with Zig 0.14.1
+- **Build System Updates**: Modernized the build system configuration for the latest Zig toolchain
+- **Full Test Suite**: All tests now pass when running `zig build test`
+
+### Fork Information
+
+This is a fork of https://github.com/The-King-of-Toasters/zig-bech32/ that maintains compatibility with modern Zig versions while preserving all original functionality.
+
+### Inherited Features
+
+From the original repository:
+- Complete Bech32 and Bech32m encoding/decoding (BIP-173 and BIP-350)
+- Generic encoder/decoder implementation
+- Comprehensive error handling
+- Extensive test coverage with official BIP test vectors
+- Single-file library design with no external dependencies
+
+### Known Issues
+
+- The bech32m encoding issue noted in https://github.com/The-King-of-Toasters/zig-bech32/issues/2 also exists with this fork

--- a/bech32.zig
+++ b/bech32.zig
@@ -2,6 +2,8 @@
 // Copyright (c) 2017 Takatoshi Nakagawa
 // Copyright (c) 2019 Google LLC
 // Copyright (c) 2021 Stephen Gregoratto
+// Copyright (c) 2023 Chris Heyes
+// Copyright (c) 2025 Eli Grubb
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/build.zig
+++ b/build.zig
@@ -25,6 +25,7 @@ pub fn build(b: *std.Build) !void {
         .root_module = b.createModule(.{
             .root_source_file = b.path("bech32.zig"),
             .target = target,
+            .optimize = optimize,
         }),
     });
 

--- a/build.zig
+++ b/build.zig
@@ -1,17 +1,35 @@
 const std = @import("std");
 
-pub fn build(b: *std.build.Builder) void {
+const version = std.SemanticVersion{ .major = 0, .minor = 1, .patch = 0 };
+
+pub fn build(b: *std.Build) !void {
     // Standard release options allow the person running `zig build` to select
     // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall.
-    const mode = b.standardReleaseOptions();
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
 
-    const lib = b.addStaticLibrary("bech32", "bech32.zig");
-    lib.setBuildMode(mode);
-    lib.install();
+    const lib = b.addLibrary(.{
+        .name = "bech32",
+        .version = version,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("bech32.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+        .linkage = .static,
+    });
+    b.installArtifact(lib);
 
-    var main_tests = b.addTest("bech32.zig");
-    main_tests.setBuildMode(mode);
+    const main_tests = b.addTest(.{
+        .version = version,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("bech32.zig"),
+            .target = target,
+        }),
+    });
+
+    const main_tests_run = b.addRunArtifact(main_tests);
 
     const test_step = b.step("test", "Run library tests");
-    test_step.dependOn(&main_tests.step);
+    test_step.dependOn(&main_tests_run.step);
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,12 @@
+.{
+    .name = .bech32,
+    .version = "0.1.0",
+    .fingerprint = 0xf6c7010a05c8de88,
+    .license = "MIT",
+    .minimum_zig_version = "0.14.1", //"0.15.0-dev.847+850655f06",
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "bech32.zig",
+    },
+}


### PR DESCRIPTION
This PR upgrades the code to Zig 0.14.1.  
  - Update build system to use new std.Build API
  - Replace deprecated @boolToInt with @intFromBool
  - Replace deprecated @enumToInt with @intFromEnum
  - Update @truncate calls to use new single-argument form
  - Update for loops to use new multi-object iteration syntax
  - Add build.zig.zon package manifest
  - Update .gitignore for new cache directory naming

Tests for updated library pass.

Note: tests also pass when run using zig-nightly (Zig 0.15.0-dev.847+850655f06).